### PR TITLE
Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,42 @@ sls deploy
 *Inputs:*
 - url: any valid url
 
+*Returns:*
+A JSON object with the bounds of the tiff.
+
 *example:*
 ```
-$ curl {you-endpoint}/bounds?url=https://any-file.on/the-internet.tif
+$ curl {your-endpoint}/bounds?url=https://any-file.on/the-internet.tif
 
   {"url": "https://any-file.on/the-internet.tif", "bounds": [90.47546096087822, 23.803014490532913, 90.48441996322644, 23.80577697976369]}
 ```
+
+## /metadata
+
+*Inputs:*
+- url: any valid url
+
+*Returns:*
+A JSON object with metadata about the tiff.
+
+*example:*
+```
+$ curl {your-endpoint}/metadata?url=https://any-file.on/the-internet.tif
+```
+
+## /viewer
+
+*Inputs:*
+- url: any valid url
+
+*Returns:*
+A Leaflet viewer that allows you to pan & zoom the tiff.
+
+*example:*
+```
+$ curl {your-endpoint}/metadata?url=https://any-file.on/the-internet.tif
+```
+
 
 #### /tiles/z/x/y.png
 
@@ -57,6 +87,20 @@ $ curl {you-endpoint}/bounds?url=https://any-file.on/the-internet.tif
 
 *example:*
 ```
-$ curl {you-endpoint}/tiles/7/10/10.png?url=https://any-file.on/the-internet.tif
+$ curl {your-endpoint}/tiles/7/10/10.png?url=https://any-file.on/the-internet.tif
 
 ```
+
+## /viewer
+
+*Inputs:*
+None
+
+*Returns:*
+A Leaflet viewer that allows you to pan & zoom on a sample tiff hosted on s3.
+
+*example:*
+```
+$ curl {your-endpoint}/viewer
+```
+

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ curl {your-endpoint}/metadata?url=https://any-file.on/the-internet.tif
 ```
 
 
-#### /tiles/z/x/y.png
+## /tiles/z/x/y.png
 
 *Inputs:*
 - url: any valid url
@@ -91,7 +91,7 @@ $ curl {your-endpoint}/tiles/7/10/10.png?url=https://any-file.on/the-internet.ti
 
 ```
 
-## /viewer
+## /example
 
 *Inputs:*
 None

--- a/lambda_tiler/handler.py
+++ b/lambda_tiler/handler.py
@@ -1,7 +1,6 @@
 """app.main: handle request for lambda-tiler."""
 
 from typing import Tuple, Union
-from typing.io import BinaryIO
 
 import re
 import json
@@ -11,7 +10,12 @@ import numpy
 from rio_tiler import main
 
 from rio_tiler.profiles import img_profiles
-from rio_tiler.utils import array_to_image, get_colormap, expression, linear_rescale
+from rio_tiler.utils import (
+    array_to_image,
+    get_colormap,
+    expression,
+    linear_rescale
+)
 
 from rio_color.operations import parse_operations
 from rio_color.utils import scale_dtype, to_math_type
@@ -37,12 +41,15 @@ def _postprocess(
         mask = numpy.zeros((tilesize, tilesize), dtype=numpy.uint8)
     else:
         if rescale:
-            rescale_arr = (tuple(map(float, rescale.split(","))),) * tile.shape[0]
+            rescale_arr = (
+                tuple(map(float, rescale.split(","))),) * tile.shape[0]
             for bdx in range(tile.shape[0]):
                 tile[bdx] = numpy.where(
                     mask,
                     linear_rescale(
-                        tile[bdx], in_range=rescale_arr[bdx], out_range=[0, 255]
+                        tile[bdx],
+                        in_range=rescale_arr[bdx],
+                        out_range=[0, 255]
                     ),
                     0,
                 )
@@ -61,6 +68,7 @@ def _postprocess(
 class TilerError(Exception):
     """Base exception class."""
 
+
 @APP.route(
     "/viewer",
     methods=["GET"],
@@ -70,21 +78,43 @@ class TilerError(Exception):
 )
 @APP.pass_event
 def viewer(
-    event: object, 
+    event: object,
     url: str
 ) -> Tuple[str, str, str]:
     """Handle Viewer requests."""
-    print(event)
     endpoint = "https://{domain}/{stage}".format(
         domain=event['requestContext']['domainName'],
         stage=event['requestContext']['stage']
     )
-    print(endpoint)
     html = viewer_template.format(
         endpoint=endpoint,
         cogurl=url
     )
-    print(html)
+    return ("OK", "text/html", html)
+
+
+@APP.route(
+    "/example",
+    methods=["GET"],
+    cors=True,
+    payload_compression_method="gzip",
+    binary_b64encode=True,
+)
+@APP.pass_event
+def example(
+    event: object
+) -> Tuple[str, str, str]:
+    """Handle Example requests."""
+    url = 'https://oin-hotosm.s3.amazonaws.com/' \
+          '5ac626e091b5310010e0d482/0/5ac626e091b5310010e0d483.tif'
+    endpoint = "https://{domain}/{stage}".format(
+        domain=event['requestContext']['domainName'],
+        stage=event['requestContext']['stage']
+    )
+    html = viewer_template.format(
+        endpoint=endpoint,
+        cogurl=url
+    )
     return ("OK", "text/html", html)
 
 
@@ -170,7 +200,8 @@ def tile(
     if expr is not None:
         tile, mask = expression(url, x, y, z, expr=expr, tilesize=tilesize)
     else:
-        tile, mask = main.tile(url, x, y, z, indexes=indexes, tilesize=tilesize)
+        tile, mask = main.tile(
+            url, x, y, z, indexes=indexes, tilesize=tilesize)
 
     rtile, rmask = _postprocess(
         tile, mask, tilesize, rescale=rescale, color_formula=color_formula
@@ -183,7 +214,8 @@ def tile(
     return (
         "OK",
         f"image/{ext}",
-        array_to_image(rtile, rmask, img_format=driver, color_map=color_map, **options),
+        array_to_image(rtile, rmask, img_format=driver,
+                       color_map=color_map, **options),
     )
 
 

--- a/lambda_tiler/handler.py
+++ b/lambda_tiler/handler.py
@@ -18,6 +18,8 @@ from rio_color.utils import scale_dtype, to_math_type
 
 from lambda_proxy.proxy import API
 
+from lambda_tiler.viewer import viewer_template
+
 APP = API(app_name="cogeo-tiler")
 
 
@@ -58,6 +60,32 @@ def _postprocess(
 
 class TilerError(Exception):
     """Base exception class."""
+
+@APP.route(
+    "/viewer",
+    methods=["GET"],
+    cors=True,
+    payload_compression_method="gzip",
+    binary_b64encode=True,
+)
+@APP.pass_event
+def viewer(
+    event: object, 
+    url: str
+) -> Tuple[str, str, str]:
+    """Handle Viewer requests."""
+    print(event)
+    endpoint = "https://{domain}/{stage}".format(
+        domain=event['requestContext']['domainName'],
+        stage=event['requestContext']['stage']
+    )
+    print(endpoint)
+    html = viewer_template.format(
+        endpoint=endpoint,
+        cogurl=url
+    )
+    print(html)
+    return ("OK", "text/html", html)
 
 
 @APP.route(

--- a/lambda_tiler/viewer.py
+++ b/lambda_tiler/viewer.py
@@ -1,3 +1,4 @@
+viewer_template="""
 <!DOCTYPE html>
 <html>
   <head>
@@ -9,8 +10,8 @@
     <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.43.0/mapbox-gl.js'></script>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.43.0/mapbox-gl.css' rel='stylesheet' />
     <style>
-      body { margin:0; padding:0; }
-      #map { position:absolute; top:0; bottom:0; width:100%; }
+      body {{ margin:0; padding:0; }}
+      #map {{ position:absolute; top:0; bottom:0; width:100%; }}
     </style>
   </head>
   <body>
@@ -18,69 +19,70 @@
     <div id='map'></div>
     <script>
 
-      var endpoint = '{YOUR-API-GATEWAY-ENDPOINT}'; //e.g https://xxxxxxxxxx.execute-api.xxxxxxx.amazonaws.com/production
+      var endpoint = '{endpoint}'; //e.g https://xxxxxxxxxx.execute-api.xxxxxxx.amazonaws.com/production
 
-      var map = new mapboxgl.Map({
+      var map = new mapboxgl.Map({{
           container: 'map',
-          style: { version: 8, sources: {}, layers: [] },
+          style: {{ version: 8, sources: {{}}, layers: [] }},
           center: [-119.5591, 37.715],
           zoom: 9
-      });
+      }});
 
-      var url = 'https://oin-hotosm.s3.amazonaws.com/5ac626e091b5310010e0d482/0/5ac626e091b5310010e0d483.tif';
+      var url = '{cogurl}';
 
-      map.on('load', () => {
+      map.on('load', () => {{
 
-        const bounds_query = `${endpoint}/bounds?url=${url}`;
+        const bounds_query = `${{endpoint}}/bounds?url=${{url}}`;
         $.getJSON(bounds_query).done()
-          .then(data => {
+          .then(data => {{
             console.log(data);
 
-            map.addSource('tiles', {
+            map.addSource('tiles', {{
                 "type": "raster",
-                "tiles": [`${endpoint}/tiles/{z}/{x}/{y}.png?url=${url}&nodata=0&tile=256`],
+                "tiles": [`${{endpoint}}/tiles/{{z}}/{{x}}/{{y}}.png?url=${{url}}&nodata=0`],
                 "tileSize": 256,
                 "bounds": data.bounds
-            });
+            }});
 
-            map.addLayer({
+            map.addLayer({{
                 "id": "tiles",
                 "source": "tiles",
                 "type": "raster"
-            });
+            }});
 
-            const geojson = {
+            const geojson = {{
               'type': 'FeatureCollection',
               'features': [turf.bboxPolygon(data.bounds)]
-            };
+            }};
 
-            map.addSource('tile', {
+            map.addSource('tile', {{
               'type': 'geojson',
               'data': geojson
-            });
+            }});
 
-            map.addLayer({
+            map.addLayer({{
                 'id': 'tile',
                 'type': 'line',
                 'source': 'tile',
-                'layout': {
+                'layout': {{
                   'line-cap': 'round',
                   'line-join': 'round'
-                },
-                'paint': {
+                }},
+                'paint': {{
                   'line-color': '#1b34db',
                   'line-width': 2
-                }
-            });
+                }}
+            }});
 
             const extent = data.bounds;
             const llb = mapboxgl.LngLatBounds.convert([[extent[0],extent[1]], [extent[2],extent[3]]]);
-            map.fitBounds(llb, {padding: 50});
+            map.fitBounds(llb, {{padding: 50}});
 
-          });
+          }});
 
-      });
+      }});
     </script>
 
   </body>
 </html>
+"""

--- a/lambda_tiler/viewer.py
+++ b/lambda_tiler/viewer.py
@@ -1,14 +1,24 @@
-viewer_template="""
+viewer_template = """
 <!DOCTYPE html>
 <html>
   <head>
     <meta charset='utf-8' />
     <title>example</title>
-    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://code.jquery.com/jquery-3.2.1.min.js'></script>
-    <script src='https://npmcdn.com/@turf/turf@3.5.1/turf.min.js'></script>
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.43.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.43.0/mapbox-gl.css' rel='stylesheet' />
+    <meta
+      name='viewport'
+      content='initial-scale=1,maximum-scale=1,user-scalable=no'
+    />
+    <script src='https://code.jquery.com/jquery-3.2.1.min.js'>
+    </script>
+    <script src='https://npmcdn.com/@turf/turf@3.5.1/turf.min.js'>
+    </script>
+    <script
+      src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.43.0/mapbox-gl.js'>
+    </script>
+    <link
+      href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.43.0/mapbox-gl.css'
+      rel='stylesheet'
+    />
     <style>
       body {{ margin:0; padding:0; }}
       #map {{ position:absolute; top:0; bottom:0; width:100%; }}
@@ -19,7 +29,7 @@ viewer_template="""
     <div id='map'></div>
     <script>
 
-      var endpoint = '{endpoint}'; //e.g https://xxxxxxxxxx.execute-api.xxxxxxx.amazonaws.com/production
+      var endpoint = '{endpoint}';
 
       var map = new mapboxgl.Map({{
           container: 'map',
@@ -39,7 +49,9 @@ viewer_template="""
 
             map.addSource('tiles', {{
                 "type": "raster",
-                "tiles": [`${{endpoint}}/tiles/{{z}}/{{x}}/{{y}}.png?url=${{url}}&nodata=0`],
+                "tiles": [
+                  `${{endpoint}}/tiles/{{z}}/{{x}}/{{y}}.png?url=${{url}}&nodata=0`
+                ],
                 "tileSize": 256,
                 "bounds": data.bounds
             }});
@@ -75,7 +87,12 @@ viewer_template="""
             }});
 
             const extent = data.bounds;
-            const llb = mapboxgl.LngLatBounds.convert([[extent[0],extent[1]], [extent[2],extent[3]]]);
+            const llb = mapboxgl.LngLatBounds.convert(
+              [
+                [extent[0],extent[1]],
+                [extent[2],extent[3]]
+              ]
+            );
             map.fitBounds(llb, {{padding: 50}});
 
           }});


### PR DESCRIPTION
This pull request moves the example.html to be hosted by the lambda itself. It adds and endpoint /example that uses the example tiff used in the original example.html and also adds a viewer that can be used for any tiff at /viewer?url=https://url.com/tiff.tif